### PR TITLE
Add ReceiveCount counter for Message attribute

### DIFF
--- a/app/gosqs/gosqs.go
+++ b/app/gosqs/gosqs.go
@@ -866,10 +866,11 @@ func getMessageResult(m *app.Message) *app.ResultMessage {
 		msgMttrs = append(msgMttrs, getMessageAttributeResult(&attr))
 	}
 
+	m.NumberOfReceives = m.NumberOfReceives + 1
 	attrsMap := map[string]string{
 		"ApproximateFirstReceiveTimestamp": fmt.Sprintf("%d", m.ReceiptTime.UnixNano()/int64(time.Millisecond)),
 		"SenderId":                         app.CurrentEnvironment.AccountID,
-		"ApproximateReceiveCount":          fmt.Sprintf("%d", m.NumberOfReceives+1),
+		"ApproximateReceiveCount":          fmt.Sprintf("%d", m.NumberOfReceives),
 		"SentTimestamp":                    fmt.Sprintf("%d", time.Now().UTC().UnixNano()/int64(time.Millisecond)),
 	}
 

--- a/app/gosqs/gosqs.go
+++ b/app/gosqs/gosqs.go
@@ -866,7 +866,7 @@ func getMessageResult(m *app.Message) *app.ResultMessage {
 		msgMttrs = append(msgMttrs, getMessageAttributeResult(&attr))
 	}
 
-	m.NumberOfReceives = m.NumberOfReceives + 1
+	m.NumberOfReceives += 1
 	attrsMap := map[string]string{
 		"ApproximateFirstReceiveTimestamp": fmt.Sprintf("%d", m.ReceiptTime.UnixNano()/int64(time.Millisecond)),
 		"SenderId":                         app.CurrentEnvironment.AccountID,

--- a/app/gosqs/gosqs_test.go
+++ b/app/gosqs/gosqs_test.go
@@ -809,6 +809,10 @@ func TestRequeueing_ResetVisibilityTimeout(t *testing.T) {
 	if ok := strings.Contains(rr.Body.String(), "<Message>"); !ok {
 		t.Fatal("handler should return a message")
 	}
+	substr := "<Name>ApproximateReceiveCount</Name>\n                  <Value>2</Value>\n"
+	if ok := strings.Contains(rr.Body.String(), substr); !ok {
+		t.Fatal("handler should return ApproximateReceiveCount message attribute")
+	}
 	done <- struct{}{}
 }
 


### PR DESCRIPTION
https://app.clubhouse.io/geckoboard/story/46321/devise-a-retry-strategy-for-event-failures

We do return `ReceiveCount` in `Message.Attributes`, however the counter never actually increased.
This commit will ensure that everytime a message got back in a queue, we'll increase the counter
by one.

This commit is needed due retry strategy that has been enforced on Roadie Replicator, where it
relies on comparing a specific maximum retry time against `Message.ReceiveCount`.

Related PR:
https://github.com/geckoboard/roadie/pull/413