### PR TITLE
Set the visibility timeout on ReceiveMessage

### DIFF
--- a/app/gosqs/gosqs.go
+++ b/app/gosqs/gosqs.go
@@ -333,20 +333,27 @@ func SendMessageBatch(w http.ResponseWriter, req *http.Request) {
 func ReceiveMessage(w http.ResponseWriter, req *http.Request) {
 	w.Header().Set("Content-Type", "application/xml")
 
-	waitTimeSeconds := 0
-	wts := req.FormValue("WaitTimeSeconds")
-	if wts != "" {
-		waitTimeSeconds, _ = strconv.Atoi(wts)
+	var (
+		maxNumberOfMessages      = 1
+		waitTimeSeconds          = 0
+		visibilityTimeoutSeconds = 0
+	)
+
+	if v := req.FormValue("WaitTimeSeconds"); v != "" {
+		waitTimeSeconds, _ = strconv.Atoi(v)
 	}
-	maxNumberOfMessages := 1
-	mom := req.FormValue("MaxNumberOfMessages")
-	if mom != "" {
-		maxNumberOfMessages, _ = strconv.Atoi(mom)
+
+	if v := req.FormValue("MaxNumberOfMessages"); v != "" {
+		maxNumberOfMessages, _ = strconv.Atoi(v)
+	}
+
+	if v := req.FormValue("VisibilityTimeout"); v != "" {
+		visibilityTimeoutSeconds, _ = strconv.Atoi(v)
 	}
 
 	queueUrl := getQueueFromPath(req.FormValue("QueueUrl"), req.URL.String())
-
 	queueName := ""
+
 	if queueUrl == "" {
 		vars := mux.Vars(req)
 		queueName = vars["queueName"]
@@ -416,7 +423,11 @@ func ReceiveMessage(w http.ResponseWriter, req *http.Request) {
 			msg := &app.SyncQueues.Queues[queueName].Messages[i]
 			msg.ReceiptHandle = msg.Uuid + "#" + uuid
 			msg.ReceiptTime = time.Now().UTC()
-			msg.VisibilityTimeout = time.Now().Add(time.Duration(app.SyncQueues.Queues[queueName].TimeoutSecs) * time.Second)
+
+			if visibilityTimeoutSeconds == 0 {
+				visibilityTimeoutSeconds = app.SyncQueues.Queues[queueName].TimeoutSecs
+			}
+			msg.VisibilityTimeout = time.Now().Add(time.Duration(visibilityTimeoutSeconds) * time.Second)
 
 			if app.SyncQueues.Queues[queueName].IsFIFO {
 				// If we got messages here it means we have not processed it yet, so get next


### PR DESCRIPTION
Receive message was not taking into account the VisiblityTimeout property on ReceiveMessage
If not provided or set to 0, message visiblity timeout will default to the value set on the Queue.